### PR TITLE
Restrict comments to injection methods

### DIFF
--- a/src/main/kotlin/gg/kpjm/injectLib/InjectLib.kt
+++ b/src/main/kotlin/gg/kpjm/injectLib/InjectLib.kt
@@ -1,10 +1,6 @@
 package gg.kpjm.injectLib
 
-import gg.kpjm.injectLib.injections.DoubleInjections.Companion.formatCurrency
-import gg.kpjm.injectLib.injections.IntegerInjections.Companion.translateRoman
-import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.plugin.java.JavaPlugin
-import java.util.Locale
 
 class InjectLib : JavaPlugin() {
 
@@ -18,6 +14,5 @@ class InjectLib : JavaPlugin() {
     }
 
     override fun onDisable() {
-
     }
 }

--- a/src/main/kotlin/gg/kpjm/injectLib/injections/DoubleInjections.kt
+++ b/src/main/kotlin/gg/kpjm/injectLib/injections/DoubleInjections.kt
@@ -8,38 +8,43 @@ class DoubleInjections {
     companion object {
 
         /**
-         * Formats a Double to a Currency format with custom Currency sign
-         * example: 10000,00 formats to 10.000,00€
+         * Formats this double using the German locale and replaces the default euro
+         * symbol with the provided one.
+         *
+         * @param c Currency symbol to substitute for the euro sign.
+         * @return Formatted currency string.
          */
-
         fun Double.formatCurrency(c: Char): String {
             val formatter = NumberFormat.getCurrencyInstance(Locale.GERMANY)
             return formatter.format(this).replace('€', c).trim()
         }
 
         /**
-         * Formats a Double to a Currency format with custom Currency sign
-         * example: 10000,00 formats to 10.000,00€
+         * Formats this double using the given locale's currency settings.
+         *
+         * @param locale Locale whose currency format should be applied.
+         * @return Formatted currency string.
          */
-
         fun Double.formatCurrency(locale: Locale): String {
             val formatter = NumberFormat.getCurrencyInstance(locale)
             return formatter.format(this).trim()
         }
 
         /**
-         * Formats a Double to a Currency format with Euro sign
-         * example: 10000,00 formats to 10.000,00€
+         * Formats this double using the German locale with the euro symbol.
+         *
+         * @return Formatted currency string including the euro sign.
          */
-
         fun Double.formatEuro(): String {
             val formatter = NumberFormat.getCurrencyInstance(Locale.GERMANY)
             return formatter.format(this).trim()
         }
 
         /**
-         * Formats a Double to a Currency format without Euro sign
-         * example: 10000,00 formats to 10.000,00
+         * Formats this double using the German locale and removes the currency
+         * symbol from the result.
+         *
+         * @return Formatted currency string without any currency symbol.
          */
         fun Double.formatEuroWithoutSymbol(): String {
             val formatter = NumberFormat.getCurrencyInstance(Locale.GERMANY)

--- a/src/main/kotlin/gg/kpjm/injectLib/injections/IntegerInjections.kt
+++ b/src/main/kotlin/gg/kpjm/injectLib/injections/IntegerInjections.kt
@@ -5,6 +5,11 @@ class IntegerInjections {
     companion object {
         private val romanNumerals = arrayOf("", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X")
 
+        /**
+         * Converts this integer to a Roman numeral if it is between 1 and 10.
+         * Returns an empty string for zero and the decimal representation for
+         * values outside the supported range.
+         */
         fun Int.translateRoman(): String {
             if (this == 0) return ""
             return if (this in 1..10) romanNumerals[this] else this.toString()

--- a/src/main/kotlin/gg/kpjm/injectLib/injections/ItemMetaInjections.kt
+++ b/src/main/kotlin/gg/kpjm/injectLib/injections/ItemMetaInjections.kt
@@ -4,22 +4,25 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Color
 import org.bukkit.inventory.meta.ItemMeta
 import org.jetbrains.annotations.ApiStatus
-
 @ApiStatus.Experimental
 class ItemMetaInjections {
 
     companion object {
 
         /**
-         * sets the displayname with minimessage
+         * Parses the provided MiniMessage string and applies it as the display
+         * name of this item meta.
+         *
+         * @param s MiniMessage string to deserialize.
          */
         fun ItemMeta.setMiniMessageDisplayName(s: String) {
             this.displayName(MiniMessage.miniMessage().deserialize(s))
         }
 
         /**
-         * adds a float to the CustomModelData of a ItemMeta
-         * float
+         * Replaces the custom model data with a single float value.
+         *
+         * @param f Float to store in the custom model data component.
          */
         fun ItemMeta.setCustomModelData(f: Float) {
             val modelDataComponent = this.customModelDataComponent
@@ -28,8 +31,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * adds a string to the CustomModelData of a ItemMeta
-         * string
+         * Replaces the custom model data with a single string value.
+         *
+         * @param s String to store in the custom model data component.
          */
         fun ItemMeta.setCustomModelData(s: String) {
             val modelDataComponent = this.customModelDataComponent
@@ -38,8 +42,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * adds a color to the CustomModelData of a ItemMeta
-         * color
+         * Replaces the custom model data with a single color value.
+         *
+         * @param c Color to store in the custom model data component.
          */
         fun ItemMeta.setCustomModelData(c: Color) {
             val modelDataComponent = this.customModelDataComponent
@@ -48,8 +53,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * adds a flag to the CustomModelData of a ItemMeta
-         * boolean
+         * Replaces the custom model data with a single boolean flag.
+         *
+         * @param b Boolean flag to store in the custom model data component.
          */
         fun ItemMeta.setCustomModelData(b: Boolean) {
             val modelDataComponent = this.customModelDataComponent
@@ -58,16 +64,16 @@ class ItemMetaInjections {
         }
 
         /**
-         * checks if the ItemMeta has a CustomModelData
+         * Determines whether this item meta contains any custom model data.
          */
         fun ItemMeta.hasCustomModelData(): Boolean {
             return hasCustomModelDataComponent()
         }
 
-
         /**
-         * checks if the ItemMeta has a specific CustomModelData
-         * float
+         * Checks if the custom model data contains the specified float value.
+         *
+         * @param f Float value to look for.
          */
         fun ItemMeta.hasCustomModelData(f: Float): Boolean {
             val modelDataComponent = this.customModelDataComponent
@@ -75,8 +81,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * checks if the ItemMeta has a specific CustomModelData
-         * string
+         * Checks if the custom model data contains the specified string value.
+         *
+         * @param s String value to look for.
          */
         fun ItemMeta.hasCustomModelData(s: String): Boolean {
             val modelDataComponent = this.customModelDataComponent
@@ -84,8 +91,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * checks if the ItemMeta has a specific CustomModelData
-         * color
+         * Checks if the custom model data contains the specified color value.
+         *
+         * @param c Color value to look for.
          */
         fun ItemMeta.hasCustomModelData(c: Color): Boolean {
             val modelDataComponent = this.customModelDataComponent
@@ -93,8 +101,9 @@ class ItemMetaInjections {
         }
 
         /**
-         * checks if the ItemMeta has a specific CustomModelData
-         * boolean
+         * Checks if the custom model data contains the specified boolean flag.
+         *
+         * @param b Boolean flag to look for.
          */
         fun ItemMeta.hasCustomModelData(b: Boolean): Boolean {
             val modelDataComponent = this.customModelDataComponent

--- a/src/main/kotlin/gg/kpjm/injectLib/injections/PlayerInjections.kt
+++ b/src/main/kotlin/gg/kpjm/injectLib/injections/PlayerInjections.kt
@@ -2,7 +2,6 @@ package gg.kpjm.injectLib.injections
 
 import gg.kpjm.injectLib.InjectLib.Companion.prefix
 import net.kyori.adventure.text.minimessage.MiniMessage
-import net.kyori.adventure.title.TitlePart
 import org.bukkit.entity.Player
 
 class PlayerInjections {
@@ -10,28 +9,36 @@ class PlayerInjections {
     companion object {
 
         /**
-         * Sends a message to the player in MiniMessage format
+         * Sends a chat message parsed from a MiniMessage string.
+         *
+         * @param s MiniMessage string to send.
          */
         fun Player.sendMiniMessage(s: String) {
             sendMessage(MiniMessage.miniMessage().deserialize(s))
         }
 
         /**
-         * Sends a message to the player in MiniMessage format with the prefix
+         * Sends a chat message with the plugin prefix parsed from a MiniMessage string.
+         *
+         * @param s MiniMessage string to send after the prefix.
          */
         fun Player.sendMiniMessageWithPrefix(s: String) {
             sendMessage(MiniMessage.miniMessage().deserialize("$prefix $s"))
         }
 
         /**
-         * Sends an actionbar to the player in MiniMessage format
+         * Displays an action bar message parsed from a MiniMessage string.
+         *
+         * @param s MiniMessage string to display.
          */
         fun Player.sendMiniMessageActionBar(s: String) {
             sendActionBar(MiniMessage.miniMessage().deserialize(s))
         }
 
         /**
-         * Sends an actionbar to the player in MiniMessage format with the prefix
+         * Displays an action bar message with the plugin prefix parsed from a MiniMessage string.
+         *
+         * @param s MiniMessage string to display after the prefix.
          */
         fun Player.sendMiniMessageActionBarWithPrefix(s: String) {
             sendActionBar(MiniMessage.miniMessage().deserialize("$prefix $s"))


### PR DESCRIPTION
## Summary
- remove plugin and class comments to keep documentation focused on injection methods
- document Double, Integer, ItemMeta, and Player injection utilities with concise KDoc

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b365d68a588333a2624e3053557b83