### PR TITLE
Bundle kotlin-reflect so dependents get working Kotlin reflection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <kotlin.version>2.2.21</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,5 +121,10 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Problem

InjectLib is loaded first and provides the shared kotlin-stdlib for dependent plugins. When its `kotlin.jvm.internal.Reflection` class initializes (at InjectLib load time), it fixes the reflection factory based on whether `kotlin-reflect` is on **its** classloader. InjectLib ships stdlib but **not** kotlin-reflect, so the factory is permanently set to "no reflection".

As a result, dependents hit `KotlinReflectionNotSupportedError` at runtime — even when they shade their own kotlin-reflect, because their copy lives on a child classloader that InjectLib's already-initialized `Reflection` can't see. On Minecraft 26.1.2 this broke e.g. TransientCore's item serialization (jackson-module-kotlin), cascading to several plugins failing to enable.

## Fix

Ship `kotlin-reflect` alongside `kotlin-stdlib-jdk8` (same `${kotlin.version}`) so it's shaded into the InjectLib jar. Then InjectLib's `Reflection` initializes with the reflection factory available, and every dependent gets working Kotlin reflection.

Verified: the built jar now contains `kotlin/reflect/jvm/internal/ReflectionFactoryImpl` alongside the stdlib.